### PR TITLE
Add Telegram bot service, OpenClaw setup script, and documentation; update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,8 @@ View your app in AI Studio: https://ai.studio/apps/drive/1UQmhRXCKCfJn_6_amLsp8Y
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+## Telegram bot deploy
+
+Voor een snelle Telegram bot deploy, zie: `docs/telegram-deploy.md`.
+De bot-service staat in `telegram-bot/` en gebruikt `TELEGRAM_BOT_TOKEN` als environment variable.

--- a/docs/openclaw-setup.md
+++ b/docs/openclaw-setup.md
@@ -1,0 +1,35 @@
+# OpenClaw opzetten
+
+Deze repository bevat een helper-script om OpenClaw automatisch te clonen en te bouwen.
+
+## Vereisten
+
+- `git`
+- `cmake`
+- een C++ toolchain (`g++`/`clang++`, `make`/`ninja`)
+
+## Gebruik
+
+```bash
+./scripts/setup-openclaw.sh
+```
+
+Optioneel kun je een doelmap meegeven:
+
+```bash
+./scripts/setup-openclaw.sh ~/projects/openclaw
+```
+
+## Build type aanpassen
+
+Standaard gebruikt het script `Release`. Voor `Debug`:
+
+```bash
+BUILD_TYPE=Debug ./scripts/setup-openclaw.sh
+```
+
+## Wat het script doet
+
+1. Clone (of update) `https://github.com/openclaw/openclaw.git`
+2. Draait CMake configuratie
+3. Bouwt het project via CMake

--- a/docs/telegram-deploy.md
+++ b/docs/telegram-deploy.md
@@ -1,0 +1,35 @@
+# Telegram bot deploy (veilig, zonder token in code)
+
+Ik heb een eenvoudige Telegram echo-bot toegevoegd in `telegram-bot/`.
+
+## Belangrijk
+
+- **Commit je token nooit in Git.**
+- Zet je token alleen als environment variable `TELEGRAM_BOT_TOKEN` in je deploy platform.
+- Omdat je token hier in chat is gedeeld, is het verstandig die te **revoken/roteren** via BotFather.
+
+## Lokaal testen
+
+```bash
+cd telegram-bot
+TELEGRAM_BOT_TOKEN=your_token_here npm start
+```
+
+## Deploy op Railway (aanrader, snel)
+
+1. Push deze repo naar GitHub.
+2. Maak een nieuw Railway project vanaf je repo.
+3. Kies service root: `telegram-bot`.
+4. Start command: `npm start`.
+5. Voeg env var toe:
+   - `TELEGRAM_BOT_TOKEN=...`
+   - optioneel `POLL_TIMEOUT_SECONDS=25`
+6. Deploy.
+
+## Healthcheck
+
+De service expose't een HTTP endpoint op `PORT` met response:
+
+```json
+{"ok":true,"service":"telegram-bot"}
+```

--- a/scripts/setup-openclaw.sh
+++ b/scripts/setup-openclaw.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_URL="https://github.com/openclaw/openclaw.git"
+TARGET_DIR="${1:-openclaw}"
+BUILD_TYPE="${BUILD_TYPE:-Release}"
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "Error: git is not installed." >&2
+  exit 1
+fi
+
+if ! command -v cmake >/dev/null 2>&1; then
+  echo "Error: cmake is not installed." >&2
+  exit 1
+fi
+
+if [ -d "$TARGET_DIR/.git" ]; then
+  echo "Repository already exists at '$TARGET_DIR'. Pulling latest changes..."
+  git -C "$TARGET_DIR" pull --ff-only
+else
+  echo "Cloning OpenClaw into '$TARGET_DIR'..."
+  git clone --recursive "$REPO_URL" "$TARGET_DIR"
+fi
+
+echo "Configuring build (type: $BUILD_TYPE)..."
+cmake -S "$TARGET_DIR" -B "$TARGET_DIR/build" -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
+
+echo "Building OpenClaw..."
+cmake --build "$TARGET_DIR/build" --config "$BUILD_TYPE"
+
+echo "Done. Build artifacts are in: $TARGET_DIR/build"

--- a/telegram-bot/index.mjs
+++ b/telegram-bot/index.mjs
@@ -1,0 +1,92 @@
+import http from 'node:http';
+
+const BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
+const POLL_TIMEOUT_SECONDS = Number(process.env.POLL_TIMEOUT_SECONDS ?? 25);
+const PORT = Number(process.env.PORT ?? 3000);
+
+if (!BOT_TOKEN) {
+  console.error('Missing TELEGRAM_BOT_TOKEN environment variable.');
+  process.exit(1);
+}
+
+const API_BASE = `https://api.telegram.org/bot${BOT_TOKEN}`;
+
+async function callTelegram(method, payload = {}) {
+  const res = await fetch(`${API_BASE}/${method}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  const data = await res.json();
+  if (!res.ok || !data.ok) {
+    const description = data?.description ?? `HTTP ${res.status}`;
+    throw new Error(`Telegram API error on ${method}: ${description}`);
+  }
+
+  return data.result;
+}
+
+let offset = 0;
+let running = true;
+
+async function handleUpdate(update) {
+  const message = update?.message;
+  const chatId = message?.chat?.id;
+  const text = message?.text;
+
+  if (!chatId || !text) return;
+
+  if (text === '/start') {
+    await callTelegram('sendMessage', {
+      chat_id: chatId,
+      text: 'Bot is live ✅\nStuur een bericht en ik echo het terug.',
+    });
+    return;
+  }
+
+  await callTelegram('sendMessage', {
+    chat_id: chatId,
+    text: `Echo: ${text}`,
+  });
+}
+
+async function pollLoop() {
+  while (running) {
+    try {
+      const updates = await callTelegram('getUpdates', {
+        offset,
+        timeout: POLL_TIMEOUT_SECONDS,
+        allowed_updates: ['message'],
+      });
+
+      for (const update of updates) {
+        offset = update.update_id + 1;
+        await handleUpdate(update);
+      }
+    } catch (error) {
+      console.error(error.message);
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+    }
+  }
+}
+
+const server = http.createServer((_, res) => {
+  res.writeHead(200, { 'content-type': 'application/json' });
+  res.end(JSON.stringify({ ok: true, service: 'telegram-bot' }));
+});
+
+server.listen(PORT, () => {
+  console.log(`Health server listening on :${PORT}`);
+});
+
+process.on('SIGTERM', () => {
+  running = false;
+  server.close();
+});
+process.on('SIGINT', () => {
+  running = false;
+  server.close();
+});
+
+await pollLoop();

--- a/telegram-bot/package.json
+++ b/telegram-bot/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "telegram-bot-service",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "node index.mjs"
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide a lightweight Telegram echo-bot service for quick deployment and local testing. 
- Add a helper script to automate cloning and building the OpenClaw project. 
- Document deployment and setup steps so contributors can run services locally and on simple hosts. 

### Description

- Update `README.md` to include a short `Telegram bot deploy` section pointing to `docs/telegram-deploy.md` and noting the `telegram-bot/` service uses `TELEGRAM_BOT_TOKEN`. 
- Add `telegram-bot/` service with `index.mjs` implementing a polling-based echo bot, a simple health HTTP endpoint, and `package.json` with a `start` script. 
- Add `scripts/setup-openclaw.sh`, an executable script that clones (or updates), configures with CMake, and builds the `openclaw` repo honoring `BUILD_TYPE`. 
- Add documentation files `docs/telegram-deploy.md` (deploy instructions, token security notes, Railway guide, and healthcheck response) and `docs/openclaw-setup.md` (prereqs and usage for the OpenClaw setup script). 

### Testing

- No automated tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab63ac94a8833294670dbc399e9034)